### PR TITLE
explrer refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ systemctl daemon-reload
 
     default view is for 50 nodes and paginated to make it faster and easier to parse, example: `?page=1`
   
-  - max_result:
+  - size:
 
-    default max result for page, example: ``?max_result=50`
+    default max result for page, example: ``?size=50`
 
 - Example full query
 
@@ -226,7 +226,7 @@ systemctl daemon-reload
 
     ```json
     // 20211012115620
-    // http://localhost:8080/gateways?max_result=1
+    // http://localhost:8080/gateways?size=1
 
       {
         "data": {
@@ -271,9 +271,9 @@ systemctl daemon-reload
 
     default view is for 50 nodes and paginated to make it faster and easier to parse, example: `?page=1`
   
-  - max_result:
+  - size:
 
-    default max result for page, example: ``?max_result=50`
+    default max result for page, example: ``?size=50`
 
 ### `/nodes/<node-id>` or `/gateways/<node-id>`
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -50,7 +50,7 @@ var doc = `{
                     {
                         "type": "integer",
                         "description": "Max result per page",
-                        "name": "max_result",
+                        "name": "size",
                         "in": "query"
                     }
                 ],
@@ -87,7 +87,7 @@ var doc = `{
                     {
                         "type": "integer",
                         "description": "Max result per page",
-                        "name": "max_result",
+                        "name": "size",
                         "in": "query"
                     },
                     {
@@ -161,7 +161,7 @@ var doc = `{
                     {
                         "type": "integer",
                         "description": "Max result per page",
-                        "name": "max_result",
+                        "name": "size",
                         "in": "query"
                     },
                     {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -36,7 +36,7 @@
                     {
                         "type": "integer",
                         "description": "Max result per page",
-                        "name": "max_result",
+                        "name": "size",
                         "in": "query"
                     }
                 ],
@@ -73,7 +73,7 @@
                     {
                         "type": "integer",
                         "description": "Max result per page",
-                        "name": "max_result",
+                        "name": "size",
                         "in": "query"
                     },
                     {
@@ -147,7 +147,7 @@
                     {
                         "type": "integer",
                         "description": "Max result per page",
-                        "name": "max_result",
+                        "name": "size",
                         "in": "query"
                     },
                     {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -249,7 +249,7 @@ paths:
         type: integer
       - description: Max result per page
         in: query
-        name: max_result
+        name: size
         type: integer
       produces:
       - application/json
@@ -273,7 +273,7 @@ paths:
         type: integer
       - description: Max result per page
         in: query
-        name: max_result
+        name: size
         type: integer
       - description: Get nodes for specific farm
         in: query
@@ -321,7 +321,7 @@ paths:
         type: integer
       - description: Max result per page
         in: query
-        name: max_result
+        name: size
         type: integer
       - description: Get nodes for specific farm
         in: query

--- a/internal/explorer/helpers.go
+++ b/internal/explorer/helpers.go
@@ -231,7 +231,7 @@ func (a *App) getNodeDMI(ctx context.Context, nodeID string, nodeClient *client.
 // fetchNodeData is a helper method that fetches nodes data over rmb
 // returns the node capacity, hypervisor and dmi
 func (a *App) fetchNodeData(nodeID string) (NodeInfo, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2 * time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*3)
 	defer cancel()
 	
 	twinID, err := a.getNodeTwinID(nodeID)

--- a/internal/explorer/helpers.go
+++ b/internal/explorer/helpers.go
@@ -227,10 +227,12 @@ func (a *App) getNodeDMI(ctx context.Context, nodeID string, nodeClient *client.
 	return dmiData, nil
 }
 
+
 // fetchNodeData is a helper method that fetches nodes data over rmb
 // returns the node capacity, hypervisor and dmi
 func (a *App) fetchNodeData(nodeID string) (NodeInfo, error) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 2 * time.Second)
+	defer cancel()
 	
 	twinID, err := a.getNodeTwinID(nodeID)
 	if err != nil {
@@ -239,7 +241,7 @@ func (a *App) fetchNodeData(nodeID string) (NodeInfo, error) {
 	
 	capacity, err := a.getNodeCapacity(ctx, nodeID, false)
 	if err != nil {
-		return NodeInfo{}, err
+		return NodeInfo{}, errors.Wrapf(err, "error fetching node capacity")
 	}
 
 	nodeClient := client.NewNodeClient(twinID, a.rmb)

--- a/internal/explorer/helpers.go
+++ b/internal/explorer/helpers.go
@@ -132,7 +132,7 @@ func getIsGateway(ctx context.Context) string {
 }
 
 func calculateMaxResult(r *http.Request) (int, error) {
-	maxResultPerpage := r.URL.Query().Get("max_result")
+	maxResultPerpage := r.URL.Query().Get("size")
 	if maxResultPerpage == "" {
 		maxResultPerpage = "50"
 	}

--- a/internal/explorer/models.go
+++ b/internal/explorer/models.go
@@ -67,8 +67,8 @@ type nodeResult struct {
 
 // CapacityResult is the NodeData capacity results to unmarshal json in it
 type capacityResult struct {
-	Total gridtypes.Capacity `json:"total"`
-	Used  gridtypes.Capacity `json:"used"`
+	Total gridtypes.Capacity `json:"total_resources"`
+	Used  gridtypes.Capacity `json:"used_resources"`
 }
 
 // NodeInfo is node specific info, queried directly from the node
@@ -120,6 +120,11 @@ func (n *NodeStatus) Deserialize(data []byte) error {
 	return nil
 }
 
+type location struct {
+	Country string `json:"country"`
+	City    string `json:"city"`
+}
+
 type publicConfig struct {
 	Domain string `json:"domain"`
 	Gw4    string `json:"gw4"`
@@ -130,25 +135,24 @@ type publicConfig struct {
 
 // Node is a struct holding the data for a node for the nodes view
 type node struct {
-	Version           int          `json:"version"`
-	ID                string       `json:"id"`
-	NodeID            int          `json:"nodeId"`
-	FarmID            int          `json:"farmId"`
-	TwinID            int          `json:"twinId"`
-	Country           string       `json:"country"`
-	GridVersion       int          `json:"gridVersion"`
-	City              string       `json:"city"`
-	Uptime            int64        `json:"uptime"`
-	Created           int64        `json:"created"`
-	FarmingPolicyID   int          `json:"farmingPolicyId"`
-	UpdatedAt         string       `json:"updatedAt"`
-	Cru               string       `json:"cru"`
-	Mru               string       `json:"mru"`
-	Sru               string       `json:"sru"`
-	Hru               string       `json:"hru"`
-	PublicConfig      publicConfig `json:"publicConfig"`
-	Status            string       `json:"status"` // added node status field for up or down
-	CertificationType string       `json:"certificationType"`
+	Version           int                `json:"version"`
+	ID                string             `json:"id"`
+	NodeID            int                `json:"nodeId"`
+	FarmID            int                `json:"farmId"`
+	TwinID            int                `json:"twinId"`
+	Country           string             `json:"country"`
+	GridVersion       int                `json:"gridVersion"`
+	City              string             `json:"city"`
+	Uptime            int64              `json:"uptime"`
+	Created           int64              `json:"created"`
+	FarmingPolicyID   int                `json:"farmingPolicyId"`
+	UpdatedAt         string             `json:"updatedAt"`
+	TotalResources    gridtypes.Capacity `json:"total_resources"`
+	UsedResources     gridtypes.Capacity `json:"used_resources"`
+	Location          location           `json:"location"`
+	PublicConfig      publicConfig       `json:"publicConfig"`
+	Status            string             `json:"status"` // added node status field for up or down
+	CertificationType string             `json:"certificationType"`
 }
 
 // Nodes is struct for the whole nodes view
@@ -176,13 +180,13 @@ type nodeIDResult struct {
 }
 
 type farm struct {
-	Name            string `json:"name"`
-	FarmID          int    `json:"farmId"`
-	TwinID          int    `json:"twinId"`
-	Version         int    `json:"version"`
-	PricingPolicyID int    `json:"pricingPolicyId"`
-	StellarAddress  string `json:"stellarAddress"`
-	PublicIps []publicIP `json:"publicIps"`
+	Name            string     `json:"name"`
+	FarmID          int        `json:"farmId"`
+	TwinID          int        `json:"twinId"`
+	Version         int        `json:"version"`
+	PricingPolicyID int        `json:"pricingPolicyId"`
+	StellarAddress  string     `json:"stellarAddress"`
+	PublicIps       []publicIP `json:"publicIps"`
 }
 
 type publicIP struct {
@@ -194,7 +198,7 @@ type publicIP struct {
 }
 
 type farmData struct {
-	Farms     []farm     `json:"farms"`
+	Farms []farm `json:"farms"`
 }
 
 // FarmResult is to unmarshal json in it

--- a/internal/explorer/models.go
+++ b/internal/explorer/models.go
@@ -182,6 +182,7 @@ type farm struct {
 	Version         int    `json:"version"`
 	PricingPolicyID int    `json:"pricingPolicyId"`
 	StellarAddress  string `json:"stellarAddress"`
+	PublicIps []publicIP `json:"publicIps"`
 }
 
 type publicIP struct {
@@ -194,7 +195,6 @@ type publicIP struct {
 
 type farmData struct {
 	Farms     []farm     `json:"farms"`
-	PublicIps []publicIP `json:"publicIps"`
 }
 
 // FarmResult is to unmarshal json in it

--- a/internal/explorer/server.go
+++ b/internal/explorer/server.go
@@ -56,13 +56,24 @@ func (a *App) listFarms(w http.ResponseWriter, r *http.Request) {
 	}
 	`, maxResult, pageOffset)
 
-	_, err = a.queryProxy(queryString, w)
+	farms := FarmResult{}
+	err = a.query(queryString, &farms)
 
 	if err != nil {
 		log.Error().Err(err).Msg("failed to query farm")
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(http.StatusText(http.StatusInternalServerError)))
 	}
+
+	result, err := json.Marshal(farms.Data.Farms)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to marshal farm")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(http.StatusText(http.StatusInternalServerError)))
+	}
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(result))
 }
 
 // listNodes godoc

--- a/internal/explorer/server.go
+++ b/internal/explorer/server.go
@@ -23,7 +23,7 @@ import (
 // @Accept  json
 // @Produce  json
 // @Param page query int false "Page number"
-// @Param max_result query int false "Max result per page"
+// @Param size query int false "Max result per page"
 // @Success 200 {object} FarmResult
 // @Router /farms [get]
 func (a *App) listFarms(w http.ResponseWriter, r *http.Request) {
@@ -72,7 +72,7 @@ func (a *App) listFarms(w http.ResponseWriter, r *http.Request) {
 // @Accept  json
 // @Produce  json
 // @Param page query int false "Page number"
-// @Param max_result query int false "Max result per page"
+// @Param size query int false "Max result per page"
 // @Param farm_id query int false "Get nodes for specific farm"
 // @Success 200 {object} nodesResponse
 // @Router /nodes [get]

--- a/internal/explorer/server.go
+++ b/internal/explorer/server.go
@@ -1,6 +1,7 @@
 package explorer
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -112,6 +113,8 @@ func (a *App) listNodes(w http.ResponseWriter, r *http.Request) {
 	}
 	var nodeList []node
 	for _, node := range nodes.Nodes.Data {
+		// check if node is down or not by checking redis key existence in redis cache and if it is down
+		// set status to down in node struct and add it to nodeList slice
 		isStored, err := a.GetRedisKey(a.getNodeKey(fmt.Sprint(node.NodeID)))
 		if err != nil {
 			node.Status = "down"
@@ -122,6 +125,21 @@ func (a *App) listNodes(w http.ResponseWriter, r *http.Request) {
 		if isStored != "" && isStored != "likely down" {
 			node.Status = "up"
 		}
+
+		node.Location.City = node.City
+		node.Location.Country = node.Country
+
+		// append the usage resources to the node object if it is up
+		if node.Status == "up" {
+			capacity, err := a.getNodeCapacity(context.Background(), fmt.Sprintf("%v", node.NodeID), false)
+			if err != nil {
+				log.Error().Err(err).Msg("error fetching node statistics")
+				continue
+			}
+			node.TotalResources = capacity.Total
+			node.UsedResources = capacity.Used
+		}
+
 		nodeList = append(nodeList, node)
 	}
 	result, err := json.Marshal(nodeList)


### PR DESCRIPTION
### _**This PR has breaking changes**_
-------
### Changes:
- rename the pagination param from `max_result` to `size`
- change the `/farms` returned data to be a list of farms, not a `data` obj
- create a split caching for the node capacity expired every 10 min
- add the capacity usage to the node info with key `used_resources`
- add the total node capacity in one obj with key `total_resources`
- add `location` key to the node obj that contain the `['country', 'city']`

### related issues
- https://github.com/threefoldtech/tfgridclient_proxy/issues/68
- https://github.com/threefoldtech/tfgridclient_proxy/issues/67
- https://github.com/threefoldtech/nodes-explorer/issues/12