### PR TITLE
return json responses

### DIFF
--- a/internal/explorer/helpers.go
+++ b/internal/explorer/helpers.go
@@ -23,11 +23,6 @@ func enableCors(w *http.ResponseWriter) {
 	(*w).Header().Set("Access-Control-Allow-Origin", "*")
 }
 
-type ErrorReply struct {
-	Error   string
-	Message string
-}
-
 func errorReplyWithStatus(err error, w http.ResponseWriter, status int) {
 	w.WriteHeader(status)
 	var res ErrorReply

--- a/internal/explorer/models.go
+++ b/internal/explorer/models.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gomodule/redigo/redis"
 	"github.com/patrickmn/go-cache"
 	"github.com/pkg/errors"
-	"github.com/threefoldtech/zos/pkg/capacity/dmi"
 	"github.com/threefoldtech/zos/pkg/gridtypes"
 	"github.com/threefoldtech/zos/pkg/rmb"
 )
@@ -22,11 +21,6 @@ var (
 // ErrBadGateway creates new error type to define node existence or server problem
 var (
 	ErrBadGateway = errors.New("bad gateway")
-)
-
-// ErrBadGateway creates new error type to define node existence or server problem
-var (
-	ErrLikelyDown = errors.New("node is likely down")
 )
 
 // App is the main app objects
@@ -74,7 +68,6 @@ type capacityResult struct {
 // NodeInfo is node specific info, queried directly from the node
 type NodeInfo struct {
 	Capacity   capacityResult `json:"capacity"`
-	DMI        dmi.DMI        `json:"dmi"`
 	Hypervisor string         `json:"hypervisor"`
 	ZosVersion string         `json:"zosVersion"`
 }

--- a/internal/explorer/models.go
+++ b/internal/explorer/models.go
@@ -72,6 +72,12 @@ type NodeInfo struct {
 	ZosVersion string         `json:"zosVersion"`
 }
 
+// ErrorReply when something bad happens at grid proxy
+type ErrorReply struct {
+	Error   string
+	Message string
+}
+
 // Serialize is the serializer for node info struct
 func (n *NodeInfo) Serialize() (json.RawMessage, error) {
 	bytes, err := json.Marshal(n)


### PR DESCRIPTION
https://github.com/threefoldtech/tfgridclient_proxy/issues/78

- "likely down" is removed as a possible state.
- errors are returned as json:
```
{
    "error": "Bad Gateway",
    "message": "couldn't get node capacity, ...."
}
```
- resources on the main node page are calculated from the cached values, not a separate call
- DMI is removed