### PR TITLE
calculate resources from contract table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN wget https://github.com/threefoldtech/go-rmb/releases/download/v0.1.10/msgbu
 RUN wget https://github.com/threefoldtech/zinit/releases/download/v0.2.6/zinit -O /sbin/zinit \
     && chmod +x /sbin/zinit
 
-RUN wget https://github.com/threefoldtech/tfgridclient_proxy/releases/download/1.3.1/server -O server \
+RUN wget https://github.com/threefoldtech/tfgridclient_proxy/releases/download/1.3.2/server -O server \
     && chmod +x server \
     && mv server /usr/bin/server
 

--- a/charts/gridproxy/Chart.yaml
+++ b/charts/gridproxy/Chart.yaml
@@ -20,4 +20,4 @@ version: 1.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.3.1
+appVersion: 1.3.2

--- a/charts/gridproxy/values.yaml
+++ b/charts/gridproxy/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: threefoldtech/gridproxy
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.3.1"
+  tag: "1.3.2"
 
   env:          
     - name: "MNEMONICS"

--- a/internal/explorer/models.go
+++ b/internal/explorer/models.go
@@ -6,7 +6,6 @@ import (
 	"github.com/patrickmn/go-cache"
 	"github.com/pkg/errors"
 	"github.com/threefoldtech/grid_proxy_server/internal/explorer/db"
-	"github.com/threefoldtech/zos/pkg/gridtypes"
 	"github.com/threefoldtech/zos/pkg/rmb"
 )
 
@@ -88,16 +87,6 @@ type location struct {
 	City    string `json:"city"`
 }
 
-// assume that the node has 2 GB memory reserved for the node itself
-func addReservedMemory(cap *db.Capacity) db.Capacity {
-	return db.Capacity{
-		CRU: cap.CRU,
-		SRU: cap.SRU,
-		HRU: cap.HRU,
-		MRU: cap.MRU + 2*gridtypes.Gigabyte,
-	}
-}
-
 // Node is a struct holding the data for a node for the nodes view
 type node struct {
 	ID                string          `json:"id"`
@@ -120,7 +109,6 @@ type node struct {
 }
 
 func nodeFromDBNode(info db.AllNodeData) node {
-	used := addReservedMemory(&info.NodeData.UsedResources)
 	return node{
 		ID:              info.NodeData.ID,
 		NodeID:          info.NodeID,
@@ -134,7 +122,7 @@ func nodeFromDBNode(info db.AllNodeData) node {
 		FarmingPolicyID: info.NodeData.FarmingPolicyID,
 		UpdatedAt:       info.NodeData.UpdatedAt,
 		TotalResources:  info.NodeData.TotalResources,
-		UsedResources:   used,
+		UsedResources:   info.NodeData.UsedResources,
 		Location: location{
 			Country: info.NodeData.Country,
 			City:    info.NodeData.City,
@@ -167,7 +155,6 @@ type nodeWithNestedCapacity struct {
 }
 
 func nodeWithNestedCapacityFromDBNode(info db.AllNodeData) nodeWithNestedCapacity {
-	used := addReservedMemory(&info.NodeData.UsedResources)
 	return nodeWithNestedCapacity{
 		ID:              info.NodeData.ID,
 		NodeID:          info.NodeID,
@@ -182,7 +169,7 @@ func nodeWithNestedCapacityFromDBNode(info db.AllNodeData) nodeWithNestedCapacit
 		UpdatedAt:       info.NodeData.UpdatedAt,
 		Capacity: capacityResult{
 			Total: info.NodeData.TotalResources,
-			Used:  used,
+			Used:  info.NodeData.UsedResources,
 		},
 		Location: location{
 			Country: info.NodeData.Country,


### PR DESCRIPTION
The calculation based on contract changes on the graphql side turned out to be complicated, so it's implemented as a query over the active contracts. If things gets too slow, materialized views can be used with periodic refreshes or triggers (will be slightly complicated).

Note: the query takes about ~7 milliseconds on a testnet dump with ~4000 contract. Using materialized views takes ~.5 milliseconds. Building the materialized view itself takes ~8 milliseconds. So the refresh approach shouldn't cause a big load.