### PR TITLE
Return valid json

### DIFF
--- a/internal/explorer/mw/action.go
+++ b/internal/explorer/mw/action.go
@@ -3,6 +3,7 @@ package mw
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -22,6 +23,7 @@ type Response interface {
 
 // Action interface
 type Action func(r *http.Request) (interface{}, Response)
+type ProxyAction func(r *http.Request) (*http.Response, Response)
 
 func enableCors(w *http.ResponseWriter) {
 	(*w).Header().Set("Access-Control-Allow-Origin", "*")
@@ -29,6 +31,72 @@ func enableCors(w *http.ResponseWriter) {
 
 func exposeHeaders(w *http.ResponseWriter) {
 	(*w).Header().Set("Access-Control-Expose-Headers", "*")
+}
+
+// AsProxyHandlerFunc returns the response in `_, response`, and proxy the http response in `response, nil`
+func AsProxyHandlerFunc(a ProxyAction) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			_, _ = ioutil.ReadAll(r.Body)
+			_ = r.Body.Close()
+		}()
+		enableCors(&w)
+		response, result := a(r)
+		defer func() {
+			if response != nil {
+				response.Body.Close()
+			}
+		}()
+
+		var headers http.Header
+		var statusCode int
+
+		// headers
+		if result != nil {
+			headers = result.Header()
+			headers.Set("Content-Type", "application/json")
+		} else if response != nil {
+			headers = response.Header
+		}
+		for k, v := range headers {
+			// override if present
+			w.Header().Set(k, v[0])
+			// add all
+			for _, v := range v[1:] {
+				w.Header().Add(k, v)
+			}
+		}
+
+		// status code
+		if result != nil {
+			statusCode = result.Status()
+		} else if response != nil {
+			statusCode = response.StatusCode
+		} else {
+			statusCode = http.StatusOK
+		}
+
+		w.WriteHeader(statusCode)
+
+		// body
+		if result != nil && result.Err() != nil {
+			// to be consistent with https://github.com/threefoldtech/rmb_go/blob/825c23c921d395294f3d28d5d9f1d009e8fde9d6/models.go#L35
+			object := struct {
+				Status  string `json:",omitempty"`
+				Message string `json:",omitempty"`
+			}{
+				Message: result.Err().Error(),
+				Status:  http.StatusText(result.Status()),
+			}
+			if err := json.NewEncoder(w).Encode(object); err != nil {
+				log.Error().Err(err).Msg("failed to encode return object")
+			}
+		} else if response != nil {
+			if _, err := io.Copy(w, response.Body); err != nil {
+				log.Error().Err(err).Msg("failed to write returned object")
+			}
+		}
+	}
 }
 
 // AsHandlerFunc is a helper wrapper to make implementing actions easier

--- a/internal/explorer/mw/action.go
+++ b/internal/explorer/mw/action.go
@@ -23,6 +23,8 @@ type Response interface {
 
 // Action interface
 type Action func(r *http.Request) (interface{}, Response)
+
+// ProxyAction interface
 type ProxyAction func(r *http.Request) (*http.Response, Response)
 
 func enableCors(w *http.ResponseWriter) {

--- a/internal/explorer/mw/action_test.go
+++ b/internal/explorer/mw/action_test.go
@@ -1,0 +1,160 @@
+package mw
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type errType struct {
+	Error string `json:"error"`
+}
+
+var (
+	HeaderExample1 = http.Header{
+		"C": []string{"D", "E"},
+	}
+	HeaderExample2 = http.Header{
+		"F": []string{"G", "H"},
+	}
+	HeaderExample3 = http.Header{
+		"I": []string{"J", "K"},
+	}
+
+	ResponseTextExample1 = "Hello world"
+	ResponseTextExample2 = "Hello world2"
+	ResponseTextExample3 = "Hello world3"
+
+	ErrExample1 = errors.New("internal grid proxy failure")
+	ErrEaxmple2 = errors.New("another internal grid proxy failure")
+
+	JSONErrExample1 = errType{
+		Error: ErrExample1.Error(),
+	}
+	JSONErrExample2 = errType{
+		Error: ErrEaxmple2.Error(),
+	}
+
+	ProxyHeaderExample1 = http.Header{
+		"L": []string{"M"},
+	}
+	ProxyHeaderExample2 = http.Header{
+		"N": []string{"O"},
+	}
+)
+
+func proxyFailureHandler(r *http.Request) (*http.Response, Response) {
+	resp := Error(ErrExample1)
+	for k, v := range ProxyHeaderExample1 {
+		resp = resp.WithHeader(k, v[0])
+	}
+	return nil, resp
+}
+
+func upstreamFailureHandler(r *http.Request) (*http.Response, Response) {
+	resp := http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     HeaderExample1,
+		Body:       io.NopCloser(strings.NewReader(ResponseTextExample1)),
+	}
+	return &resp, nil
+}
+
+func successHandler(r *http.Request) (*http.Response, Response) {
+	resp := http.Response{
+		StatusCode: http.StatusOK,
+		Header:     HeaderExample2,
+		Body:       io.NopCloser(strings.NewReader(ResponseTextExample2)),
+	}
+	return &resp, nil
+}
+
+// returns the mw.Response
+func bothResponsesPresnet(r *http.Request) (*http.Response, Response) {
+	httpResp := http.Response{
+		StatusCode: http.StatusOK,
+		Header:     HeaderExample3,
+		Body:       io.NopCloser(strings.NewReader(ResponseTextExample3)),
+	}
+	resp := Error(ErrEaxmple2)
+	for k, v := range ProxyHeaderExample2 {
+		resp = resp.WithHeader(k, v[0])
+	}
+
+	return &httpResp, resp
+}
+
+func TestProxyGridProxyError(t *testing.T) {
+	handler := AsProxyHandlerFunc(proxyFailureHandler)
+	w := httptest.NewRecorder()
+	handler(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	if w.Result().StatusCode != http.StatusInternalServerError {
+		t.Fatalf("grid proxy status code mismatch: expected: %d, found: %d", http.StatusInternalServerError, w.Result().StatusCode)
+	}
+	if !reflect.DeepEqual(w.Header(), ProxyHeaderExample1) {
+		t.Fatalf("grid proxy header mismatch: expected: %v, found: %v", ProxyHeaderExample1, w.Header())
+	}
+	var err errType
+	if err := json.NewDecoder(w.Body).Decode(&err); err != nil {
+		t.Fatalf("failed to decode response body: %s", err.Error())
+	}
+	if !reflect.DeepEqual(err, JSONErrExample1) {
+		t.Fatalf("grid proxy error mismatch: expected: %v, found: %v", JSONErrExample1, err)
+	}
+}
+
+func TestProxyUpstreamError(t *testing.T) {
+	handler := AsProxyHandlerFunc(upstreamFailureHandler)
+	w := httptest.NewRecorder()
+	handler(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	if w.Result().StatusCode != http.StatusBadRequest {
+		t.Fatalf("upstream error status code mismatch: expected: %d, found: %d", http.StatusBadRequest, w.Result().StatusCode)
+	}
+	if !reflect.DeepEqual(w.Header(), HeaderExample1) {
+		t.Fatalf("upstream error header mismatch: expected: %v, found: %v", HeaderExample1, w.Header())
+	}
+	body := w.Body.String()
+	if body != ResponseTextExample1 {
+		t.Fatalf("upstream error error mismatch: expected: %v, found: %v", ResponseTextExample1, body)
+	}
+}
+
+func TestProxySuccess(t *testing.T) {
+	handler := AsProxyHandlerFunc(successHandler)
+	w := httptest.NewRecorder()
+	handler(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("upstream success status code mismatch: expected: %d, found: %d", http.StatusOK, w.Result().StatusCode)
+	}
+	if !reflect.DeepEqual(w.Header(), HeaderExample2) {
+		t.Fatalf("upstream success header mismatch: expected: %v, found: %v", HeaderExample2, w.Header())
+	}
+	body := w.Body.String()
+	if body != ResponseTextExample2 {
+		t.Fatalf("upstream success error mismatch: expected: %v, found: %v", ResponseTextExample2, body)
+	}
+}
+
+func TestBothResponses(t *testing.T) {
+	handler := AsProxyHandlerFunc(bothResponsesPresnet)
+	w := httptest.NewRecorder()
+	handler(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	if w.Result().StatusCode != http.StatusInternalServerError {
+		t.Fatalf("both result status code mismatch: expected: %d, found: %d", http.StatusInternalServerError, w.Result().StatusCode)
+	}
+	if !reflect.DeepEqual(w.Header(), ProxyHeaderExample2) {
+		t.Fatalf("both result header mismatch: expected: %v, found: %v", ProxyHeaderExample2, w.Header())
+	}
+	var err errType
+	if err := json.NewDecoder(w.Body).Decode(&err); err != nil {
+		t.Fatalf("failed to decode response body: %s", err.Error())
+	}
+	if !reflect.DeepEqual(err, JSONErrExample2) {
+		t.Fatalf("both result error mismatch: expected: %v, found: %v", JSONErrExample2, err)
+	}
+}

--- a/internal/rmbproxy/models.go
+++ b/internal/rmbproxy/models.go
@@ -2,6 +2,7 @@ package rmbproxy
 
 import (
 	"bytes"
+	"net/http"
 
 	"github.com/threefoldtech/substrate-client"
 )
@@ -38,6 +39,6 @@ type twinClient struct {
 
 // TwinClient interface
 type TwinClient interface {
-	SubmitMessage(msg bytes.Buffer) (string, error)
-	GetResult(msgID MessageIdentifier) (string, error)
+	SubmitMessage(msg bytes.Buffer) (*http.Response, error)
+	GetResult(msgID MessageIdentifier) (*http.Response, error)
 }

--- a/internal/rmbproxy/server.go
+++ b/internal/rmbproxy/server.go
@@ -2,27 +2,17 @@ package rmbproxy
 
 import (
 	"bytes"
-	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 
 	// swagger configuration
 	"github.com/pkg/errors"
+	"github.com/threefoldtech/grid_proxy_server/internal/explorer/mw"
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog/log"
 	httpSwagger "github.com/swaggo/http-swagger"
 )
-
-func errorReply(w http.ResponseWriter, status int, message string) {
-	w.WriteHeader(status)
-	fmt.Fprintf(w, "{\"status\": \"error\", \"message\": \"%s\"}", message)
-}
-
-func enableCors(w *http.ResponseWriter) {
-	(*w).Header().Set("Access-Control-Allow-Origin", "*")
-}
 
 // NewTwinClient : create new TwinClient
 func (a *App) NewTwinClient(twinID int) (TwinClient, error) {
@@ -49,8 +39,7 @@ func (a *App) NewTwinClient(twinID int) (TwinClient, error) {
 // @Param twin_id path int true "twin id"
 // @Success 200 {object} MessageIdentifier
 // @Router /twin/{twin_id} [post]
-func (a *App) sendMessage(w http.ResponseWriter, r *http.Request) {
-	enableCors(&w)
+func (a *App) sendMessage(r *http.Request) (*http.Response, mw.Response) {
 	twinIDString := mux.Vars(r)["twin_id"]
 
 	buffer := new(bytes.Buffer)
@@ -58,26 +47,20 @@ func (a *App) sendMessage(w http.ResponseWriter, r *http.Request) {
 
 	twinID, err := strconv.Atoi(twinIDString)
 	if err != nil {
-		errorReply(w, http.StatusBadRequest, "Invalid twinId")
-		return
+		return nil, mw.BadRequest(errors.Wrap(err, "invalid twin_id"))
 	}
 
 	c, err := a.NewTwinClient(twinID)
 	if err != nil {
-		log.Error().Err(err).Msg("failed to create TwinClient")
-		errorReply(w, http.StatusInternalServerError, "failed to create TwinClient")
-		return
+		log.Error().Err(err).Msg("failed to create twin client")
+		return nil, mw.Error(errors.Wrap(err, "failed to create twin client"))
 	}
 
-	data, err := c.SubmitMessage(*buffer)
+	response, err := c.SubmitMessage(*buffer)
 	if err != nil {
-		errorReply(w, http.StatusBadRequest, err.Error())
-		return
+		return nil, mw.Error(errors.Wrap(err, "failed to submit message"))
 	}
-
-	w.Header().Add("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(data))
+	return response, nil
 }
 
 // getResult godoc
@@ -90,8 +73,7 @@ func (a *App) sendMessage(w http.ResponseWriter, r *http.Request) {
 // @Param retqueue path string true "message retqueue"
 // @Success 200 {array} Message
 // @Router /twin/{twin_id}/{retqueue} [get]
-func (a *App) getResult(w http.ResponseWriter, r *http.Request) {
-	enableCors(&w)
+func (a *App) getResult(r *http.Request) (*http.Response, mw.Response) {
 	twinIDString := mux.Vars(r)["twin_id"]
 	retqueue := mux.Vars(r)["retqueue"]
 
@@ -101,27 +83,20 @@ func (a *App) getResult(w http.ResponseWriter, r *http.Request) {
 
 	twinID, err := strconv.Atoi(twinIDString)
 	if err != nil {
-		errorReply(w, http.StatusBadRequest, "Invalid twinId")
-		return
+		return nil, mw.BadRequest(errors.Wrap(err, "invalid twin_id"))
 	}
 
 	c, err := a.NewTwinClient(twinID)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to create twin client")
-		errorReply(w, http.StatusInternalServerError, "failed to create twin client")
-		return
+		return nil, mw.Error(errors.Wrap(err, "failed to create twin client"))
 	}
 
-	data, err := c.GetResult(reqBody)
+	response, err := c.GetResult(reqBody)
 	if err != nil {
-		log.Error().Err(err).Msg("failed to get result")
-		errorReply(w, http.StatusBadRequest, err.Error())
-		return
+		return nil, mw.Error(errors.Wrap(err, "failed to submit message"))
 	}
-
-	w.Header().Add("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(data))
+	return response, nil
 }
 
 // ping godoc
@@ -132,15 +107,8 @@ func (a *App) getResult(w http.ResponseWriter, r *http.Request) {
 // @Produce  json
 // @Success 200 {object} string "pong"
 // @Router /ping [get]
-func (a *App) ping(w http.ResponseWriter, r *http.Request) {
-	enableCors(&w)
-	ret := map[string]string{"ping": "pong"}
-
-	data, _ := json.Marshal(ret)
-
-	w.Header().Add("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(data))
+func (a *App) ping(r *http.Request) (interface{}, mw.Response) {
+	return map[string]string{"ping": "pong"}, mw.Ok()
 }
 
 // Setup : sets rmb routes
@@ -165,9 +133,9 @@ func Setup(router *mux.Router, substrate string) error {
 		resolver: *resolver,
 	}
 
-	router.HandleFunc("/twin/{twin_id:[0-9]+}", a.sendMessage)
-	router.HandleFunc("/twin/{twin_id:[0-9]+}/{retqueue}", a.getResult)
-	router.HandleFunc("/ping", a.ping)
+	router.HandleFunc("/twin/{twin_id:[0-9]+}", mw.AsProxyHandlerFunc(a.sendMessage))
+	router.HandleFunc("/twin/{twin_id:[0-9]+}/{retqueue}", mw.AsProxyHandlerFunc(a.getResult))
+	router.HandleFunc("/ping", mw.AsHandlerFunc(a.ping))
 	router.PathPrefix("/swagger").Handler(httpSwagger.WrapHandler)
 
 	return nil

--- a/internal/rmbproxy/server.go
+++ b/internal/rmbproxy/server.go
@@ -58,7 +58,7 @@ func (a *App) sendMessage(r *http.Request) (*http.Response, mw.Response) {
 
 	response, err := c.SubmitMessage(*buffer)
 	if err != nil {
-		return nil, mw.Error(errors.Wrap(err, "failed to submit message"))
+		return nil, mw.BadGateway(errors.Wrap(err, "failed to submit message"))
 	}
 	return response, nil
 }
@@ -94,7 +94,7 @@ func (a *App) getResult(r *http.Request) (*http.Response, mw.Response) {
 
 	response, err := c.GetResult(reqBody)
 	if err != nil {
-		return nil, mw.Error(errors.Wrap(err, "failed to submit message"))
+		return nil, mw.BadGateway(errors.Wrap(err, "failed to submit message"))
 	}
 	return response, nil
 }

--- a/internal/rmbproxy/twin.go
+++ b/internal/rmbproxy/twin.go
@@ -43,46 +43,26 @@ func (c *twinClient) readError(r io.Reader) string {
 	return body.Message
 }
 
-func (c *twinClient) SubmitMessage(msg bytes.Buffer) (string, error) {
+func (c *twinClient) SubmitMessage(msg bytes.Buffer) (*http.Response, error) {
 	resp, err := http.Post(submitURL(c.dstIP), "application/json", &msg)
 	// check on response for non-communication errors?
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to Submit the message: %s (%s)", resp.Status, c.readError(resp.Body))
-	}
-
-	buffer := new(bytes.Buffer)
-	buffer.ReadFrom(resp.Body)
-	response := buffer.String()
-
-	return response, nil
+	return resp, nil
 }
 
-func (c *twinClient) GetResult(msgIdentifier MessageIdentifier) (string, error) {
+func (c *twinClient) GetResult(msgIdentifier MessageIdentifier) (*http.Response, error) {
 	var buffer bytes.Buffer
 	if err := json.NewEncoder(&buffer).Encode(msgIdentifier); err != nil {
-		return "", err
+		return nil, err
 	}
 	resp, err := http.Post(resultURL(c.dstIP), "application/json", &buffer)
 
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		// body
-		return "", fmt.Errorf("failed to send remote: %s (%s)", resp.Status, c.readError(resp.Body))
-	}
-
-	buffer.ReadFrom(resp.Body)
-	response := buffer.String()
-
-	return response, err
+	return resp, err
 }


### PR DESCRIPTION
- Changed to forward the error returned from the node AS IS, previously it was checking itself for the status code and returning a proxy error instead of the original one. This was causing 400 return codes for node internal errors.
- The error is now valid json

Fixes https://github.com/threefoldtech/tfgridclient_proxy/issues/134