### PR TITLE
Dynamically list all routes when visiting the index page

### DIFF
--- a/internal/explorer/server.go
+++ b/internal/explorer/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -337,11 +338,23 @@ func (a *App) listContracts(r *http.Request) (interface{}, mw.Response) {
 	}
 	return contracts, resp
 }
+func (a *App) indexPage(m *mux.Router) mw.Action {
+	return func(r *http.Request) (interface{}, mw.Response) {
+		response := mw.Ok()
+		welcome_msg := "welcome to grid proxy server, available endpoints "
+		message := []string{welcome_msg}
+		m.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+			path, err := route.GetPathTemplate()
+			if err != nil {
+				return nil
+			}
 
-func (a *App) indexPage(r *http.Request) (interface{}, mw.Response) {
-	response := mw.Ok()
-	message := "welcome to grid proxy server, available endpoints [/farms, /nodes, /nodes/<node-id>]"
-	return message, response
+			msg := path
+			message = append(message, "["+msg+"]")
+			return nil
+		})
+		return strings.Join(message, " "), response
+	}
 }
 
 func (a *App) version(r *http.Request) (interface{}, mw.Response) {
@@ -383,7 +396,7 @@ func Setup(router *mux.Router, redisServer string, gitCommit string, database db
 	router.HandleFunc("/gateways/{node_id:[0-9]+}", mw.AsHandlerFunc(a.getGateway))
 	router.HandleFunc("/nodes/{node_id:[0-9]+}/status", mw.AsHandlerFunc(a.getNodeStatus))
 	router.HandleFunc("/gateways/{node_id:[0-9]+}/status", mw.AsHandlerFunc(a.getNodeStatus))
-	router.HandleFunc("/", mw.AsHandlerFunc(a.indexPage))
+	router.HandleFunc("/", mw.AsHandlerFunc(a.indexPage(router)))
 	router.HandleFunc("/version", mw.AsHandlerFunc(a.version))
 	router.PathPrefix("/swagger").Handler(httpSwagger.WrapHandler)
 

--- a/internal/explorer/server.go
+++ b/internal/explorer/server.go
@@ -344,7 +344,7 @@ func (a *App) indexPage(m *mux.Router) mw.Action {
 		var sb strings.Builder
 		sb.WriteString("Welcome to threefold grid proxy server, available endpoints ")
 
-		m.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+		_ = m.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
 			path, err := route.GetPathTemplate()
 			if err != nil {
 				return nil

--- a/internal/explorer/server.go
+++ b/internal/explorer/server.go
@@ -350,8 +350,7 @@ func (a *App) indexPage(m *mux.Router) mw.Action {
 				return nil
 			}
 
-			msg := path
-			sb.WriteString("[" + msg + "] ")
+			sb.WriteString("[" + path + "] ")
 			return nil
 		})
 		return sb.String(), response

--- a/internal/explorer/server.go
+++ b/internal/explorer/server.go
@@ -341,8 +341,9 @@ func (a *App) listContracts(r *http.Request) (interface{}, mw.Response) {
 func (a *App) indexPage(m *mux.Router) mw.Action {
 	return func(r *http.Request) (interface{}, mw.Response) {
 		response := mw.Ok()
-		welcome_msg := "welcome to grid proxy server, available endpoints "
-		message := []string{welcome_msg}
+		var sb strings.Builder
+		sb.WriteString("Welcome to threefold grid proxy server, available endpoints ")
+
 		m.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
 			path, err := route.GetPathTemplate()
 			if err != nil {
@@ -350,10 +351,10 @@ func (a *App) indexPage(m *mux.Router) mw.Action {
 			}
 
 			msg := path
-			message = append(message, "["+msg+"]")
+			sb.WriteString("[" + msg + "] ")
 			return nil
 		})
-		return strings.Join(message, " "), response
+		return sb.String(), response
 	}
 }
 


### PR DESCRIPTION
### Description

Dynamically list all routes when visiting the index page `/`.

### Changes

update the welcome message and dynamically list all available endpoints.

![Screenshot from 2022-12-20 12-42-01](https://user-images.githubusercontent.com/42457449/208649143-bdb033af-8463-42c0-b6a2-d22dd648ce14.png)

### Related Issues
https://github.com/threefoldtech/tfgridclient_proxy/issues/235


