### PR TITLE
Development add long lat to location

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -934,6 +934,21 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "gridtypes.Unit": {
+            "type": "integer",
+            "enum": [
+                1024,
+                1048576,
+                1073741824,
+                1099511627776
+            ],
+            "x-enum-varnames": [
+                "Kilobyte",
+                "Megabyte",
+                "Gigabyte",
+                "Terabyte"
+            ]
+        },
         "rmbproxy.Message": {
             "type": "object",
             "properties": {
@@ -1018,13 +1033,13 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "hru": {
-                    "type": "integer"
+                    "$ref": "#/definitions/gridtypes.Unit"
                 },
                 "mru": {
-                    "type": "integer"
+                    "$ref": "#/definitions/gridtypes.Unit"
                 },
                 "sru": {
-                    "type": "integer"
+                    "$ref": "#/definitions/gridtypes.Unit"
                 }
             }
         },
@@ -1167,6 +1182,12 @@ const docTemplate = `{
                 },
                 "country": {
                     "type": "string"
+                },
+                "latitude": {
+                    "type": "number"
+                },
+                "longitude": {
+                    "type": "number"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -926,6 +926,21 @@
         }
     },
     "definitions": {
+        "gridtypes.Unit": {
+            "type": "integer",
+            "enum": [
+                1024,
+                1048576,
+                1073741824,
+                1099511627776
+            ],
+            "x-enum-varnames": [
+                "Kilobyte",
+                "Megabyte",
+                "Gigabyte",
+                "Terabyte"
+            ]
+        },
         "rmbproxy.Message": {
             "type": "object",
             "properties": {
@@ -1010,13 +1025,13 @@
                     "type": "integer"
                 },
                 "hru": {
-                    "type": "integer"
+                    "$ref": "#/definitions/gridtypes.Unit"
                 },
                 "mru": {
-                    "type": "integer"
+                    "$ref": "#/definitions/gridtypes.Unit"
                 },
                 "sru": {
-                    "type": "integer"
+                    "$ref": "#/definitions/gridtypes.Unit"
                 }
             }
         },
@@ -1159,6 +1174,12 @@
                 },
                 "country": {
                     "type": "string"
+                },
+                "latitude": {
+                    "type": "number"
+                },
+                "longitude": {
+                    "type": "number"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,17 @@
 basePath: /
 definitions:
+  gridtypes.Unit:
+    enum:
+    - 1024
+    - 1048576
+    - 1073741824
+    - 1099511627776
+    type: integer
+    x-enum-varnames:
+    - Kilobyte
+    - Megabyte
+    - Gigabyte
+    - Terabyte
   rmbproxy.Message:
     properties:
       cmd:
@@ -60,11 +72,11 @@ definitions:
       cru:
         type: integer
       hru:
-        type: integer
+        $ref: '#/definitions/gridtypes.Unit'
       mru:
-        type: integer
+        $ref: '#/definitions/gridtypes.Unit'
       sru:
-        type: integer
+        $ref: '#/definitions/gridtypes.Unit'
     type: object
   types.CapacityResult:
     properties:
@@ -158,6 +170,10 @@ definitions:
         type: string
       country:
         type: string
+      latitude:
+        type: number
+      longitude:
+        type: number
     type: object
   types.Node:
     properties:

--- a/internal/explorer/converters.go
+++ b/internal/explorer/converters.go
@@ -37,8 +37,10 @@ func nodeFromDBNode(info db.Node) types.Node {
 			MRU: gridtypes.Unit(info.UsedMru),
 		},
 		Location: types.Location{
-			Country: info.Country,
-			City:    info.City,
+			Country:   info.Country,
+			City:      info.City,
+			Longitude: info.Longitude,
+			Latitude:  info.Latitude,
 		},
 		PublicConfig: types.PublicConfig{
 			Domain: info.Domain,

--- a/internal/explorer/db/types.go
+++ b/internal/explorer/db/types.go
@@ -1,6 +1,8 @@
 package db
 
-import "github.com/threefoldtech/grid_proxy_server/pkg/types"
+import (
+	"github.com/threefoldtech/grid_proxy_server/pkg/types"
+)
 
 // Database interface for storing and fetching grid info
 type Database interface {
@@ -59,6 +61,8 @@ type Node struct {
 	RentContractID  int64
 	RentedByTwinID  int64
 	SerialNumber    string
+	Longitude       *float64
+	Latitude        *float64
 }
 
 // Farm data about a farm which is calculated from the chain

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -144,8 +144,10 @@ type ContractFilter struct {
 }
 
 type Location struct {
-	Country string `json:"country"`
-	City    string `json:"city"`
+	Country   string   `json:"country"`
+	City      string   `json:"city"`
+	Longitude *float64 `json:"longitude"`
+	Latitude  *float64 `json:"latitude"`
 }
 
 // Node is a struct holding the data for a Node for the nodes view


### PR DESCRIPTION
### Description

- Adding Longitude and Latitude to Node Location struct.
- Update swagger doc.

### Changes

- Modifying the  SQL node query.
- Adding **longitude** and **latitude** to node location struct.
- Adding custom SQL function to cast the text type to decimal and return null in case of empty string/invalid entry.
- Both values Return from API as JSON **Numbers** and could be **Null**. **clients who consume the API should handle the null value.**

### Related Issues

https://github.com/threefoldtech/tfgridclient_proxy/issues/132
https://github.com/threefoldtech/tfgrid_dashboard/issues/410

### Checklist

- [ ] Tests included
- [X] Build pass
- [X] Documentation
- [X] Code format and docstrings
