### PR TITLE
filling long and lat in nodeWithNestedCapacity

### DIFF
--- a/internal/explorer/converters.go
+++ b/internal/explorer/converters.go
@@ -109,8 +109,10 @@ func nodeWithNestedCapacityFromDBNode(info db.Node) types.NodeWithNestedCapacity
 			},
 		},
 		Location: types.Location{
-			Country: info.Country,
-			City:    info.City,
+			Country:   info.Country,
+			City:      info.City,
+			Longitude: info.Longitude,
+			Latitude:  info.Latitude,
 		},
 		PublicConfig: types.PublicConfig{
 			Domain: info.Domain,


### PR DESCRIPTION
### Description

Recently we added long and lat to API response, due to having two different types for node, `types.Node` and `types.NodeWithNestedCapacity` some endpoints returns response using the first type, like /nodes, and another return response using the second type, links /nodes/{id}, in the recent commit we filled only the first type, `types.Node` with long and lat data, and overlooked updating the other model `NodeWithNestedCapacity`.

This PR should add the data to the second type as well.

### Changes

- Add long and lat to `types.NodeWithNestedCapacity`.

### Related Issues

List of related issues
https://github.com/threefoldtech/tfgridclient_proxy/issues/132
