### PR TITLE
return an error if /gateways/<id> not a gateway

### DIFF
--- a/internal/explorer/helpers.go
+++ b/internal/explorer/helpers.go
@@ -15,6 +15,8 @@ import (
 func errorReply(err error) mw.Response {
 	if errors.Is(err, ErrNodeNotFound) {
 		return mw.NotFound(err)
+	} else if errors.Is(err, ErrGatewayNotFound) {
+		return mw.NotFound(err)
 	} else if errors.Is(err, ErrBadGateway) {
 		return mw.BadGateway(err)
 	} else {

--- a/internal/explorer/models.go
+++ b/internal/explorer/models.go
@@ -12,7 +12,8 @@ import (
 
 // ErrNodeNotFound creates new error type to define node existence or server problem
 var (
-	ErrNodeNotFound = errors.New("node not found")
+	ErrNodeNotFound    = errors.New("node not found")
+	ErrGatewayNotFound = errors.New("gateway not found")
 )
 
 // ErrBadGateway creates new error type to define node existence or server problem

--- a/internal/explorer/server.go
+++ b/internal/explorer/server.go
@@ -225,7 +225,15 @@ func (a *App) getNode(r *http.Request) (interface{}, mw.Response) {
 // @Failure 500 {object} string
 // @Router /gateways/{node_id} [get]
 func (a *App) getGateway(r *http.Request) (interface{}, mw.Response) {
-	return a._getNode(r)
+	node, err := a._getNode(r)
+
+	if err != nil {
+		return nil, err
+	} else if node.(types.NodeWithNestedCapacity).PublicConfig.Domain == "" {
+		return nil, errorReply(errors.New("node not a gateway"))
+	} else {
+		return node, nil
+	}
 }
 
 func (a *App) _getNode(r *http.Request) (interface{}, mw.Response) {

--- a/internal/explorer/server.go
+++ b/internal/explorer/server.go
@@ -230,7 +230,7 @@ func (a *App) getGateway(r *http.Request) (interface{}, mw.Response) {
 	if err != nil {
 		return nil, err
 	} else if node.(types.NodeWithNestedCapacity).PublicConfig.Domain == "" {
-		return nil, errorReply(errors.New("node not a gateway"))
+		return nil, errorReply(ErrGatewayNotFound)
 	} else {
 		return node, nil
 	}


### PR DESCRIPTION
### Description
return error "node not a gateway"

### Changes

edits in `internal/explorer/server.go` `getGateway` function.

### Related Issues

- https://github.com/threefoldtech/tfgridclient_proxy/issues/225

### Checklist

- [x] Tests pass
- [x] Build pass
- [x] Code format and docstrings
