### PR TITLE
clarify node status parameter

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -314,7 +314,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Node status filter, 'up': for only up nodes \u0026 'down': for all up/down nodes.",
+                        "description": "Node status filter, 'up': for only up nodes \u0026 'down': for only down nodes.",
                         "name": "status",
                         "in": "query"
                     },
@@ -523,7 +523,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Node status filter, 'up': for only up nodes \u0026 'down': for all up/down nodes.",
+                        "description": "Node status filter, 'up': for only up nodes \u0026 'down': for only down nodes.",
                         "name": "status",
                         "in": "query"
                     },
@@ -713,7 +713,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Node status filter, 'up': for only up nodes \u0026 'down': for all up/down nodes.",
+                        "description": "Node status filter, 'up': for only up nodes \u0026 'down': for only down nodes.",
                         "name": "status",
                         "in": "query"
                     }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -306,7 +306,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Node status filter, 'up': for only up nodes \u0026 'down': for all up/down nodes.",
+                        "description": "Node status filter, 'up': for only up nodes \u0026 'down': for only down nodes.",
                         "name": "status",
                         "in": "query"
                     },
@@ -515,7 +515,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Node status filter, 'up': for only up nodes \u0026 'down': for all up/down nodes.",
+                        "description": "Node status filter, 'up': for only up nodes \u0026 'down': for only down nodes.",
                         "name": "status",
                         "in": "query"
                     },
@@ -705,7 +705,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Node status filter, 'up': for only up nodes \u0026 'down': for all up/down nodes.",
+                        "description": "Node status filter, 'up': for only up nodes \u0026 'down': for only down nodes.",
                         "name": "status",
                         "in": "query"
                     }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -502,7 +502,7 @@ paths:
         name: free_ips
         type: integer
       - description: 'Node status filter, ''up'': for only up nodes & ''down'': for
-          all up/down nodes.'
+          only down nodes.'
         in: query
         name: status
         type: string
@@ -641,7 +641,7 @@ paths:
         name: free_ips
         type: integer
       - description: 'Node status filter, ''up'': for only up nodes & ''down'': for
-          all up/down nodes.'
+          only down nodes.'
         in: query
         name: status
         type: string
@@ -767,7 +767,7 @@ paths:
       description: Get statistics about the grid
       parameters:
       - description: 'Node status filter, ''up'': for only up nodes & ''down'': for
-          all up/down nodes.'
+          only down nodes.'
         in: query
         name: status
         type: string

--- a/internal/explorer/server.go
+++ b/internal/explorer/server.go
@@ -86,7 +86,7 @@ func (a *App) listFarms(r *http.Request) (interface{}, mw.Response) {
 // @Tags GridProxy
 // @Accept  json
 // @Produce  json
-// @Param status query string false "Node status filter, 'up': for only up nodes & 'down': for all up/down nodes."
+// @Param status query string false "Node status filter, 'up': for only up nodes & 'down': for only down nodes."
 // @Success 200 {object} []types.Counters
 // @Failure 400 {object} string
 // @Failure 500 {object} string
@@ -116,7 +116,7 @@ func (a *App) getStats(r *http.Request) (interface{}, mw.Response) {
 // @Param free_hru query int false "Min free reservable hru in bytes"
 // @Param free_sru query int false "Min free reservable sru in bytes"
 // @Param free_ips query int false "Min number of free ips in the farm of the node"
-// @Param status query string false "Node status filter, 'up': for only up nodes & 'down': for all up/down nodes."
+// @Param status query string false "Node status filter, 'up': for only up nodes & 'down': for only down nodes."
 // @Param city query string false "Node city filter"
 // @Param country query string false "Node country filter"
 // @Param farm_name query string false "Get nodes for specific farm"
@@ -150,7 +150,7 @@ func (a *App) getNodes(r *http.Request) (interface{}, mw.Response) {
 // @Param free_hru query int false "Min free reservable hru in bytes"
 // @Param free_sru query int false "Min free reservable sru in bytes"
 // @Param free_ips query int false "Min number of free ips in the farm of the node"
-// @Param status query string false "Node status filter, 'up': for only up nodes & 'down': for all up/down nodes."
+// @Param status query string false "Node status filter, 'up': for only up nodes & 'down': for only down nodes."
 // @Param city query string false "Node city filter"
 // @Param country query string false "Node country filter"
 // @Param farm_name query string false "Get nodes for specific farm"


### PR DESCRIPTION
### Description

clarify/unify the use of node status parameters across all the endpoints involved. 
Now the behavior for `/stats`, `/nodes` and `/gateways` is:
- "up" for the online nodes
- "down" for the offline nodes
- no status will list all nodes on the network

### Changes
- change the use of the parameter in `state` endpoint to be 'up' for up nodes and 'down' for down nodes.
- update swagger docs for `status` parameter in `nodes`, `gateways` and `stats`

### Related Issues

- https://github.com/threefoldtech/tfgridclient_proxy/issues/224

### Checklist

- [x] Tests pass
- [x] Build pass
- [x] Code format and docstrings
