### PR TITLE
making rmb timeout value configurable, default 30

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ ENV POSTGRES_USER="postgres"
 ENV POSTGRES_PASSWORD="123"
 ENV SUBSTRATE="wss://tfchain.dev.grid.tf/ws"
 ENV REDIS="tcp://127.0.0.1:6379"
+ENV RMB_TIMEOUT="30"
 
 EXPOSE 443 8051
 ENTRYPOINT [ "zinit", "init" ]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -42,6 +42,7 @@ ENV POSTGRES_USER="postgres"
 ENV POSTGRES_PASSWORD="123"
 ENV SUBSTRATE="wss://tfchain.dev.grid.tf/ws"
 ENV REDIS="tcp://127.0.0.1:6379"
+ENV RMB_TIMEOUT="30"
 
 EXPOSE 443 8051
 ENTRYPOINT [ "zinit", "init" ]

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To list all the available tasks for running:
 | -postgres-user | postgres username  |
 | -redis | redis url (default `"tcp://127.0.0.1:6379"`)  |
 | -substrate-user | substrate url (default`"wss://tfchain.dev.grid.tf/ws"`)  |
-| -rmb-timeout | time out for rmb requests (default `30`) |
+| -rmb-timeout | timeout for rmb requests (default `30` seconds) |
 | -v | shows the package version |
 
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ To list all the available tasks for running:
 | -postgres-user | postgres username  |
 | -redis | redis url (default `"tcp://127.0.0.1:6379"`)  |
 | -substrate-user | substrate url (default`"wss://tfchain.dev.grid.tf/ws"`)  |
+| -rmb-timeout | time out for rmb requests (default `30`) |
 | -v | shows the package version |
 
 
@@ -166,7 +167,7 @@ To build & run dockerfile
 
 ```bash
 docker build -t threefoldtech/gridproxy .
-docker run --name gridproxy -e MNEMONICS="" -e SUBSTRATE="wss://tfchain.dev.grid.tf/ws" -e PUBLIC_KEY="5011157c2451b238c99247b9f0793f66e5b77998272c00676d23767fe3d576d8" -e PRIVATE_KEY="ff5b3012dbec23e86e2fde7dcd3c951781e87fe505be225488b50a6bb27662f75011157c2451b238c99247b9f0793f66e5b77998272c00676d23767fe3d576d8" -e POSTGRES_HOST="127.0.0.1" -e POSTGRES_PORT="5432" -e POSTGRES_DB="db" -e POSTGRES_USER="postgres" -e POSTGRES_PASSWORD="password" --cap-add=NET_ADMIN threefoldtech/gridproxy
+docker run --name gridproxy -e MNEMONICS="" -e SUBSTRATE="wss://tfchain.dev.grid.tf/ws" -e PUBLIC_KEY="5011157c2451b238c99247b9f0793f66e5b77998272c00676d23767fe3d576d8" -e PRIVATE_KEY="ff5b3012dbec23e86e2fde7dcd3c951781e87fe505be225488b50a6bb27662f75011157c2451b238c99247b9f0793f66e5b77998272c00676d23767fe3d576d8" -e POSTGRES_HOST="127.0.0.1" -e POSTGRES_PORT="5432" -e POSTGRES_DB="db" -e POSTGRES_USER="postgres" -e POSTGRES_PASSWORD="password" -e RMB_TIMEOUT="30" --cap-add=NET_ADMIN threefoldtech/gridproxy
 ```
 
 - PUBLIC_KEY: yggdrasil public key

--- a/charts/gridproxy/README.md
+++ b/charts/gridproxy/README.md
@@ -37,7 +37,7 @@
   **Note**: EXPLORER_URL, SERVER_IP and REDIS_URL has default values you may not pass them if you want to use the defaults
 
   ```bash
-  helm install -f values.yaml gridproxy . --set ingress.host="gridproxy.3botmain.grid.tf" --set env.MNEMONICS="" --set env.SUBSTRATE="wss://tfchain.dev.grid.tf/ws" --set env.PUBLIC_KEY="5011157c2451b238c99247b9f0793f66e5b77998272c00676d23767fe3d576d8" --set env.PRIVATE_KEY="ff5b3012dbec23e86e2fde7dcd3c951781e87fe505be225488b50a6bb27662f75011157c2451b238c99247b9f0793f66e5b77998272c00676d23767fe3d576d8" --set env.PEERS="  tls:\\\/\\\/62.210.85.80:39575\\\n   tls:\\\/\\\/54.37.137.221:11129\\\n" --set env.POSTGRES_HOST="127.0.0.1" --set env.POSTGRES_PORT="5432" --set env.POSTGRES_DB="db" --set env.POSTGRES_USER="postgres" --set env.POSTGRES_PASSWORD="password"
+  helm install -f values.yaml gridproxy . --set ingress.host="gridproxy.3botmain.grid.tf" --set env.MNEMONICS="" --set env.SUBSTRATE="wss://tfchain.dev.grid.tf/ws" --set env.PUBLIC_KEY="5011157c2451b238c99247b9f0793f66e5b77998272c00676d23767fe3d576d8" --set env.PRIVATE_KEY="ff5b3012dbec23e86e2fde7dcd3c951781e87fe505be225488b50a6bb27662f75011157c2451b238c99247b9f0793f66e5b77998272c00676d23767fe3d576d8" --set env.PEERS="  tls:\\\/\\\/62.210.85.80:39575\\\n   tls:\\\/\\\/54.37.137.221:11129\\\n" --set env.POSTGRES_HOST="127.0.0.1" --set env.POSTGRES_PORT="5432" --set env.POSTGRES_DB="db" --set env.POSTGRES_USER="postgres" --set env.POSTGRES_PASSWORD="password" --set env.RMB_TIMEOUT="30"
   ```
 
 - PUBLIC_KEY: yggdrasil public key

--- a/charts/gridproxy/values.yaml
+++ b/charts/gridproxy/values.yaml
@@ -37,6 +37,8 @@ image:
       value: "postgres"
     - name: "POSTGRES_PASSWORD"
       value: "123"
+    - name: "RMB_TIMEOUT"
+      value: "30"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/cmds/proxy_server/main.go
+++ b/cmds/proxy_server/main.go
@@ -26,22 +26,22 @@ const (
 var GitCommit string
 
 type flags struct {
-	debug            string
-	redis            string
-	postgresHost     string
-	postgresPort     int
-	postgresDB       string
-	postgresUser     string
-	postgresPassword string
-	address          string
-	substrate        string
-	domain           string
-	TLSEmail         string
-	CA               string
-	certCacheDir     string
-	version          bool
-	nocert           bool
-	rmbTimeout       int
+	debug             string
+	redis             string
+	postgresHost      string
+	postgresPort      int
+	postgresDB        string
+	postgresUser      string
+	postgresPassword  string
+	address           string
+	substrate         string
+	domain            string
+	TLSEmail          string
+	CA                string
+	certCacheDir      string
+	version           bool
+	nocert            bool
+	rmbTimeoutSeconds int
 }
 
 func main() {
@@ -61,7 +61,7 @@ func main() {
 	flag.BoolVar(&f.version, "v", false, "shows the package version")
 	flag.StringVar(&f.certCacheDir, "cert-cache-dir", CertDefaultCacheDir, "path to store generated certs in")
 	flag.BoolVar(&f.nocert, "no-cert", false, "start the server without certificate")
-	flag.IntVar(&f.rmbTimeout, "rmb-timeout", 30, "rmb requests timeout (default 30 sec)")
+	flag.IntVar(&f.rmbTimeoutSeconds, "rmb-timeout", 30, "rmb requests timeout (default 30 sec)")
 	flag.Parse()
 
 	// shows version and exit
@@ -152,7 +152,7 @@ func createServer(f flags, gitCommit string, substrate *substrate.Substrate) (*h
 	if err := explorer.Setup(router, f.redis, gitCommit, db); err != nil {
 		return nil, err
 	}
-	if err := rmbproxy.Setup(router, substrate, f.rmbTimeout); err != nil {
+	if err := rmbproxy.Setup(router, substrate, f.rmbTimeoutSeconds); err != nil {
 		return nil, err
 	}
 

--- a/cmds/proxy_server/main.go
+++ b/cmds/proxy_server/main.go
@@ -41,6 +41,7 @@ type flags struct {
 	certCacheDir     string
 	version          bool
 	nocert           bool
+	rmbTimeout       int
 }
 
 func main() {
@@ -60,6 +61,7 @@ func main() {
 	flag.BoolVar(&f.version, "v", false, "shows the package version")
 	flag.StringVar(&f.certCacheDir, "cert-cache-dir", CertDefaultCacheDir, "path to store generated certs in")
 	flag.BoolVar(&f.nocert, "no-cert", false, "start the server without certificate")
+	flag.IntVar(&f.rmbTimeout, "rmb-timeout", 30, "rmb requests timeout (default 30 sec)")
 	flag.Parse()
 
 	// shows version and exit
@@ -150,7 +152,7 @@ func createServer(f flags, gitCommit string, substrate *substrate.Substrate) (*h
 	if err := explorer.Setup(router, f.redis, gitCommit, db); err != nil {
 		return nil, err
 	}
-	if err := rmbproxy.Setup(router, substrate); err != nil {
+	if err := rmbproxy.Setup(router, substrate, f.rmbTimeout); err != nil {
 		return nil, err
 	}
 

--- a/internal/rmbproxy/models.go
+++ b/internal/rmbproxy/models.go
@@ -35,7 +35,8 @@ type Flags struct {
 
 // TwinExplorerResolver is Substrate resolver
 type TwinExplorerResolver struct {
-	client *substrate.Substrate
+	client     *substrate.Substrate
+	rmbTimeout int
 }
 
 // NewTwinClient : create new TwinClient
@@ -48,12 +49,14 @@ func (t *TwinExplorerResolver) Get(twinID int) (TwinClient, error) {
 	log.Debug().Str("ip", twin.IP).Msg("resolved twin ip")
 
 	return &twinClient{
-		dstIP: twin.IP,
+		dstIP:   twin.IP,
+		timeout: t.rmbTimeout,
 	}, nil
 }
 
 type twinClient struct {
-	dstIP string
+	dstIP   string
+	timeout int
 }
 
 // TwinClient interface

--- a/internal/rmbproxy/models.go
+++ b/internal/rmbproxy/models.go
@@ -3,6 +3,7 @@ package rmbproxy
 import (
 	"bytes"
 	"net/http"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/threefoldtech/substrate-client"
@@ -36,7 +37,7 @@ type Flags struct {
 // TwinExplorerResolver is Substrate resolver
 type TwinExplorerResolver struct {
 	client     *substrate.Substrate
-	rmbTimeout int
+	rmbTimeout time.Duration
 }
 
 // NewTwinClient : create new TwinClient
@@ -56,7 +57,7 @@ func (t *TwinExplorerResolver) Get(twinID int) (TwinClient, error) {
 
 type twinClient struct {
 	dstIP   string
-	timeout int
+	timeout time.Duration
 }
 
 // TwinClient interface

--- a/internal/rmbproxy/server.go
+++ b/internal/rmbproxy/server.go
@@ -115,10 +115,10 @@ func (a *App) ping(r *http.Request) (interface{}, mw.Response) {
 // @license.url http://www.apache.org/licenses/LICENSE-2.0.html
 // @host localhost:8080
 // @BasePath /
-func Setup(router *mux.Router, substrate *substrate.Substrate) error {
+func Setup(router *mux.Router, substrate *substrate.Substrate, rmbTimeout int) error {
 	log.Info().Msg("Creating server")
 
-	resolver, err := NewTwinResolver(substrate)
+	resolver, err := NewTwinResolver(substrate, rmbTimeout)
 	if err != nil {
 		return errors.Wrap(err, "couldn't get a client to explorer resolver")
 	}

--- a/internal/rmbproxy/server.go
+++ b/internal/rmbproxy/server.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"strconv"
+	"time"
 
 	// swagger configuration
 	"github.com/pkg/errors"
@@ -115,10 +116,10 @@ func (a *App) ping(r *http.Request) (interface{}, mw.Response) {
 // @license.url http://www.apache.org/licenses/LICENSE-2.0.html
 // @host localhost:8080
 // @BasePath /
-func Setup(router *mux.Router, substrate *substrate.Substrate, rmbTimeout int) error {
+func Setup(router *mux.Router, substrate *substrate.Substrate, rmbTimeoutSeconds int) error {
 	log.Info().Msg("Creating server")
 
-	resolver, err := NewTwinResolver(substrate, rmbTimeout)
+	resolver, err := NewTwinResolver(substrate, time.Duration(rmbTimeoutSeconds)*time.Second)
 	if err != nil {
 		return errors.Wrap(err, "couldn't get a client to explorer resolver")
 	}

--- a/internal/rmbproxy/twin.go
+++ b/internal/rmbproxy/twin.go
@@ -12,11 +12,6 @@ import (
 	"github.com/threefoldtech/substrate-client"
 )
 
-const (
-	// timeout in sec for rmb proxy requests, should be defined with a sensible timeout
-	TIMEOUT = 10
-)
-
 func submitURL(twinIP string) string {
 	return fmt.Sprintf("http://%s:8051/zbus-cmd", twinIP)
 }
@@ -26,15 +21,16 @@ func resultURL(twinIP string) string {
 }
 
 // NewTwinResolver : create a new substrate resolver
-func NewTwinResolver(substrate *substrate.Substrate) (*TwinExplorerResolver, error) {
+func NewTwinResolver(substrate *substrate.Substrate, rmbTimeout int) (*TwinExplorerResolver, error) {
 
 	return &TwinExplorerResolver{
-		client: substrate,
+		client:     substrate,
+		rmbTimeout: rmbTimeout,
 	}, nil
 }
 
 func (c *twinClient) SubmitMessage(msg bytes.Buffer) (*http.Response, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), TIMEOUT*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.timeout))
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, submitURL(c.dstIP), &msg)
@@ -61,7 +57,7 @@ func (c *twinClient) GetResult(msgIdentifier MessageIdentifier) (*http.Response,
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), TIMEOUT*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.timeout))
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resultURL(c.dstIP), &buffer)

--- a/internal/rmbproxy/twin.go
+++ b/internal/rmbproxy/twin.go
@@ -21,7 +21,7 @@ func resultURL(twinIP string) string {
 }
 
 // NewTwinResolver : create a new substrate resolver
-func NewTwinResolver(substrate *substrate.Substrate, rmbTimeout int) (*TwinExplorerResolver, error) {
+func NewTwinResolver(substrate *substrate.Substrate, rmbTimeout time.Duration) (*TwinExplorerResolver, error) {
 
 	return &TwinExplorerResolver{
 		client:     substrate,
@@ -30,7 +30,7 @@ func NewTwinResolver(substrate *substrate.Substrate, rmbTimeout int) (*TwinExplo
 }
 
 func (c *twinClient) SubmitMessage(msg bytes.Buffer) (*http.Response, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.timeout))
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, submitURL(c.dstIP), &msg)
@@ -57,7 +57,7 @@ func (c *twinClient) GetResult(msgIdentifier MessageIdentifier) (*http.Response,
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.timeout))
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resultURL(c.dstIP), &buffer)

--- a/rootfs/etc/zinit/gridproxy.yaml
+++ b/rootfs/etc/zinit/gridproxy.yaml
@@ -1,4 +1,4 @@
-exec: sh -c "/usr/bin/server --address $SERVER_PORT --redis $REDIS --substrate $SUBSTRATE --no-cert --postgres-host $POSTGRES_HOST --postgres-port $POSTGRES_PORT --postgres-db $POSTGRES_DB --postgres-user $POSTGRES_USER --postgres-password $POSTGRES_PASSWORD"
+exec: sh -c "/usr/bin/server --address $SERVER_PORT --redis $REDIS --substrate $SUBSTRATE --no-cert --postgres-host $POSTGRES_HOST --postgres-port $POSTGRES_PORT --postgres-db $POSTGRES_DB --postgres-user $POSTGRES_USER --postgres-password $POSTGRES_PASSWORD --rmb-timeout $RMB_TIMEOUT"
 log: stdout
 after:
   - msgbus


### PR DESCRIPTION
### Description

making RMB requests timeout value configurable and default to 30 sec as suggested by @xmonader
 
### Changes

- increase the context timeout for remote rmb calls from 10 to 30 
- new env variable `RMB_TIMEOUT` sets in Dockerfile to the default value `30` which can be overridden.
- new CLI option  `--rmb-timout`
- update the helm chart `values.yaml` to include new env and the default value `30` 
- update the docs and chart docs

### Related Issues

https://github.com/threefoldtech/tfgridclient_proxy/issues/264

### Checklist

- [ ] Tests included
- [ ] Build pass
- [X] Documentation
- [X] Code format and docstrings
