### PR TITLE
fix timeout context canceled

### DIFF
--- a/internal/rmbproxy/models.go
+++ b/internal/rmbproxy/models.go
@@ -50,14 +50,14 @@ func (t *TwinExplorerResolver) Get(twinID int) (TwinClient, error) {
 	log.Debug().Str("ip", twin.IP).Msg("resolved twin ip")
 
 	return &twinClient{
-		dstIP:   twin.IP,
-		timeout: t.rmbTimeout,
+		dstIP:      twin.IP,
+		httpClient: &http.Client{Timeout: t.rmbTimeout},
 	}, nil
 }
 
 type twinClient struct {
-	dstIP   string
-	timeout time.Duration
+	dstIP      string
+	httpClient *http.Client
 }
 
 // TwinClient interface

--- a/internal/rmbproxy/twin.go
+++ b/internal/rmbproxy/twin.go
@@ -30,7 +30,7 @@ func NewTwinResolver(substrate *substrate.Substrate, rmbTimeout time.Duration) (
 
 func (c *twinClient) SubmitMessage(msg bytes.Buffer) (*http.Response, error) {
 
-	resp, err := c.httpClient.Post(resultURL(c.dstIP), "application/json", &msg)
+	resp, err := c.httpClient.Post(submitURL(c.dstIP), "application/json", &msg)
 
 	if err != nil {
 		log.Error().Str("dstIP", c.dstIP).Msg(err.Error())


### PR DESCRIPTION
### Description

in commit 14e8e54ee3ca  the new code introduced was handling the timeout of RMB requests by setting a timeout per request using [context.WithTimeout()](https://pkg.go.dev/context#WithTimeout) method. 
since Go's context package sometime is hard to reason about, we got a bug that caused this [issue](https://github.com/threefoldtech/grid_weblets/issues/1258)

this PR should fix that issue and also make things easier, as it switches from using Go's context package and `http.NewRequestWithContext` , instead now it initializes the client with the Timeout field set to a custom value. the HTTP client added to the `twinClient` struct.
 

### Related Issues
https://github.com/threefoldtech/grid_weblets/issues/1258
https://github.com/threefoldtech/tfgridclient_proxy/issues/264