### PR TITLE
Fix contract created at timestamp

### DIFF
--- a/internal/explorer/db/postgres.go
+++ b/internal/explorer/db/postgres.go
@@ -603,7 +603,7 @@ func (d *PostgresDatabase) GetContracts(filter types.ContractFilter, limit types
 			"contracts.contract_id",
 			"twin_id",
 			"state",
-			"CAST(created_at / 1000 AS int) as created_at",
+			"created_at",
 			"name",
 			"node_id",
 			"deployment_data",

--- a/tests/queries/local_client.go
+++ b/tests/queries/local_client.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"math"
 	"sort"
 	"strings"
 
@@ -178,7 +177,7 @@ func (g *GridProxyClientimpl) Contracts(filter proxytypes.ContractFilter, limit 
 				ContractID: uint(contract.contract_id),
 				TwinID:     uint(contract.twin_id),
 				State:      contract.state,
-				CreatedAt:  uint(math.Round(float64(contract.created_at) / 1000.0)),
+				CreatedAt:  uint(contract.created_at),
 				Type:       "node",
 				Details: proxytypes.NodeContractDetails{
 					NodeID:            uint(contract.node_id),
@@ -197,7 +196,7 @@ func (g *GridProxyClientimpl) Contracts(filter proxytypes.ContractFilter, limit 
 				ContractID: uint(contract.contract_id),
 				TwinID:     uint(contract.twin_id),
 				State:      contract.state,
-				CreatedAt:  uint(math.Round(float64(contract.created_at) / 1000.0)),
+				CreatedAt:  uint(contract.created_at),
 				Type:       "rent",
 				Details: proxytypes.RentContractDetails{
 					NodeID: uint(contract.node_id),
@@ -213,7 +212,7 @@ func (g *GridProxyClientimpl) Contracts(filter proxytypes.ContractFilter, limit 
 				ContractID: uint(contract.contract_id),
 				TwinID:     uint(contract.twin_id),
 				State:      contract.state,
-				CreatedAt:  uint(math.Round(float64(contract.created_at) / 1000.0)),
+				CreatedAt:  uint(contract.created_at),
 				Type:       "name",
 				Details: proxytypes.NameContractDetails{
 					Name: contract.name,

--- a/tools/db/generate.go
+++ b/tools/db/generate.go
@@ -308,7 +308,7 @@ func generateNodes(db *sql.DB) error {
 		sru := rnd(200, 30*1024) * 1024 * 1024 * 1024 // 100GB -> 30TB
 		cru := rnd(4, 128)
 		up := flip(nodeUpRatio)
-		updatedAt := time.Now().Unix()*1000 - int64(rnd(60*60*2, 60*60*24*30*12))
+		updatedAt := time.Now().Unix() - int64(rnd(60*60*3, 60*60*24*30*12))
 		if up {
 			updatedAt = time.Now().Unix() - int64(rnd(0, 60*60*1))
 		}
@@ -332,7 +332,7 @@ func generateNodes(db *sql.DB) error {
 			uptime:            1000,
 			updated_at:        uint64(updatedAt),
 			created:           uint64(time.Now().Unix()),
-			created_at:        uint64(time.Now().Unix()) * 1000,
+			created_at:        uint64(time.Now().Unix()),
 			farming_policy_id: 1,
 			grid_version:      3,
 			certification:     "Diy",


### PR DESCRIPTION
### Description

- Fix contract `created_at` timestamp
- Fix for generate DB tool

### Changes

- remove the conversation from ms to seconds done on contracts careted_at filed as now it is stored in the DB in seconds
- fix generate DB tool. now the generated nodes will be based on configured up/down ratio vs all up, caused by the absolute conversion. 
 
### Related Issues

https://github.com/threefoldtech/tfgridclient_proxy/issues/276

### Checklist

- [X] Tests included
- [X] Build pass
- [ ] Documentation
- [X] Code format and docstrings
