### PR TITLE
docker image tags should not be prepended with a v

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           images: ghcr.io/threefoldtech/gridproxy
           tags: |
-            type=semver,pattern={{raw}}
+            type=semver,pattern={{version}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v3

--- a/charts/gridproxy/Chart.yaml
+++ b/charts/gridproxy/Chart.yaml
@@ -20,4 +20,4 @@ version: 1.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v1.7.0-rc3
+appVersion: 1.7.0-rc3


### PR DESCRIPTION
### Description

Align the docker image tag with the updated guidelines

### Changes

Remove the 'v'-prefix from the published docker image tag on a release

### Related Issues

#282 

