### PR TITLE
make state filter case insensitive

### DIFF
--- a/internal/explorer/db/postgres.go
+++ b/internal/explorer/db/postgres.go
@@ -634,7 +634,7 @@ func (d *PostgresDatabase) GetContracts(filter types.ContractFilter, limit types
 		q = q.Where("type = ?", *filter.Type)
 	}
 	if filter.State != nil {
-		q = q.Where("state = ?", *filter.State)
+		q = q.Where("state ILIKE ?", *filter.State)
 	}
 	if filter.TwinID != nil {
 		q = q.Where("twin_id = ?", *filter.TwinID)


### PR DESCRIPTION
### Description

change state filter to be case insensitive when listing contracts.

### Changes

Use `ILIKE` when qerying DB by state

### Related Issues

https://github.com/threefoldtech/tfgridclient_proxy/issues/228

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
