### PR TITLE
fix returning nil in twins list

### DIFF
--- a/internal/explorer/db/postgres.go
+++ b/internal/explorer/db/postgres.go
@@ -590,7 +590,7 @@ func (d *PostgresDatabase) GetTwins(filter types.TwinFilter, limit types.Limit) 
 			Offset(int(limit.Page-1) * int(limit.Size)).
 			Order("twin.twin_id")
 	}
-	var twins []types.Twin
+	twins := []types.Twin{}
 
 	if res := q.Scan(&twins); res.Error != nil {
 		return twins, uint(count), errors.Wrap(res.Error, "failed to scan returned twins from database")


### PR DESCRIPTION
### Description

Fix returning nil in twins list instead of an empty list when nothing satisfies the query parameters.

### Changes

Initialize the result slice as an empty slice before using in db querying so it retains the empty list value after being encoded.

### Related Issues

https://github.com/threefoldtech/tfgridclient_proxy/issues/302

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
